### PR TITLE
fix package typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ This library can be used by dotnet applications to access and manage items in 1P
 You can install the SDK using NUGET.
 
 ```dotnetcli
-dotnet add pacakge 1Password.Connect.Sdk
+dotnet add package 1Password.Connect.Sdk
 ```
 
 If you want to integrate with HttpClientFactory and Microsoft.Extensions.DependencyInjection
 
 ```dotnetcli
-dotnet add pacakge 1Password.Connect.Extensions.DependencyInjection
+dotnet add package 1Password.Connect.Extensions.DependencyInjection
 ```
 
 ## ✨ Get Started


### PR DESCRIPTION
Noticed a typo when installing the nuget package here https://www.nuget.org/packages/1Password.Connect.Sdk